### PR TITLE
Fix/initial color

### DIFF
--- a/src/color-picker.bundle.js
+++ b/src/color-picker.bundle.js
@@ -159,7 +159,7 @@
         }
 
         function $onChanges() {
-            if (this.color) {
+            if (this.color && 'red' in this.color && 'green' in this.color && 'blue' in this.color) {
                 this.angle = ColorPickerService.rgbToHsl(this.color.red, this.color.green, this.color.blue).hue;
             }
         }

--- a/src/color-picker.component.js
+++ b/src/color-picker.component.js
@@ -159,7 +159,7 @@
         }
 
         function $onChanges() {
-            if (this.color) {
+            if (this.color && 'red' in this.color && 'green' in this.color && 'blue' in this.color) {
                 this.angle = ColorPickerService.rgbToHsl(this.color.red, this.color.green, this.color.blue).hue;
             }
         }


### PR DESCRIPTION
Fixes an issue where the user passes empty object as initial color and the knob will not move anymore.
Steps to reproduce:
```html
<color-picker color="$ctrl.color"></color-picker>
```
```js
function DemoCtrl() {
  this.color = {};
}
```