### PR TITLE
fix(colorPicker): Fix init logic in angular@1.5.4 and lower

### DIFF
--- a/src/color-picker.bundle.js
+++ b/src/color-picker.bundle.js
@@ -156,11 +156,16 @@
             knob.addEventListener('transitionend', _onKnobTransitionEnd);
             ripple.addEventListener('animationend', _onRippleAnimationEnd);
             palette.addEventListener('transitionend', _onPaletteTransitionEnd);
+
+            // @fix angular < 1.5.4 doesn't trigger $onChanges properly on init
+            $onChanges.call(this);
         }
 
         function $onChanges() {
             if (this.color && 'red' in this.color && 'green' in this.color && 'blue' in this.color) {
                 this.angle = ColorPickerService.rgbToHsl(this.color.red, this.color.green, this.color.blue).hue;
+            } else {
+                this.angle = 0;
             }
         }
 

--- a/src/color-picker.component.js
+++ b/src/color-picker.component.js
@@ -156,11 +156,16 @@
             knob.addEventListener('transitionend', _onKnobTransitionEnd);
             ripple.addEventListener('animationend', _onRippleAnimationEnd);
             palette.addEventListener('transitionend', _onPaletteTransitionEnd);
+
+            // @fix angular < 1.5.4 doesn't trigger $onChanges properly on init
+            $onChanges.call(this);
         }
 
         function $onChanges() {
             if (this.color && 'red' in this.color && 'green' in this.color && 'blue' in this.color) {
                 this.angle = ColorPickerService.rgbToHsl(this.color.red, this.color.green, this.color.blue).hue;
+            } else {
+                this.angle = 0;
             }
         }
 


### PR DESCRIPTION
Fixes issue where the `$onChanges()` life-cycle hook is not triggered in some specific scenarios in angular@1.5.4 or lower (which happens to be the current version of angular that is used in Ionic v1)