### PR TITLE
fix(rotator): Don't prevent dragging while mouse is over color selector

### DIFF
--- a/src/scss/color-picker.scss
+++ b/src/scss/color-picker.scss
@@ -93,6 +93,10 @@ color-picker {
         top: -10%;
         left: -10%;
         z-index: 9;
+
+        &.dragging {
+            z-index: 11;
+        }
     }
 
     .color {


### PR DESCRIPTION
User feedback: currently if the user starts rotating with the mouse and the pointer moves above the center area where color selector the rotation stops and the user has to return to a draggable area and continue where the rotation was left off.

Fix is fairly straight-forward - move the rotator layer to be above everything else