### PR TITLE
fix: Add default width when generating conic gradient

### DIFF
--- a/src/color-picker-conic-gradient.directive.js
+++ b/src/color-picker-conic-gradient.directive.js
@@ -2,6 +2,7 @@ import ConicGradient from './conic-gradient.js';
 
 export default function colorPickerConicGradient() {
     return function ($scope, $element) {
-        $element[0].style.background = new ConicGradient($element[0].offsetWidth).toString();
+        var size = $element[0].offsetWidth || 280;
+        $element[0].style.background = new ConicGradient(size).toString();
     }
 }


### PR DESCRIPTION
Fixes an issue with the generated conic gradient when the color picker is hidden with `display: none` which will report an `offsetWidth` of 0.